### PR TITLE
feat: add graph abstraction

### DIFF
--- a/hytoperm/Abstraction.py
+++ b/hytoperm/Abstraction.py
@@ -1,0 +1,68 @@
+
+# external imports
+import networkx as nx
+
+# internal imports
+from .World import *
+from .GlobalPlanning import *
+
+class AbstractionOptions:
+    def __init__(self):
+        self.onlyDirectConnections : bool = True
+
+class GraphAbstraction:
+    def __init__(
+            self, 
+            world : World, 
+            gpp : GlobalPathPlanner, 
+            opts : AbstractionOptions = None):
+        self.graph : nx.DiGraph = None
+        self.options : AbstractionOptions = None
+        self.setOptions(opts)
+        self.abstract(world, gpp)
+
+    def setOptions(self, opts : AbstractionOptions):
+        if opts is None:
+            self.options = AbstractionOptions()
+            return
+        if not isinstance(opts, AbstractionOptions):
+            raise ValueError("opts must be of type AbstractionOptions")        
+        self.options = opts
+
+    def abstract(self, world : World, gpp : GlobalPathPlanner):
+        self.graph = nx.MultiDiGraph()
+        self.graph.add_nodes_from(world.targets())
+        for t1 in world.targets():
+            for t2 in world.targets():
+                if t1 == t2:
+                    continue
+                path, time = gpp.planPathToTarget(t1.p(), t2)
+                
+                # No connection if no path found
+                if path is None or time >= np.inf:
+                    continue
+
+                # No connection if we choose to drop indirect connections
+                if self.options.onlyDirectConnections:
+                    if not gpp.isDirectConnection(t1, t2, path):
+                        continue
+
+                # otherwise add the edge
+                self.graph.add_edge(t1, t2, weight=time, path=path)
+
+    def plotAbstraction(self, ax : plt.Axes = None, **kwargs):
+        pos = nx.spring_layout(self.graph)
+        for target in self.graph.nodes:
+            pos[target] = target.p()
+        
+        # draw nodes
+        node_labels = {}
+        target : Target
+        for target in self.graph.nodes:
+            node_labels[target] = target.name
+        nx.draw(self.graph, pos, ax=ax, labels=node_labels, with_labels=True, font_size=10)
+        
+        # draw edges
+        edge_labels = nx.get_edge_attributes(self.graph, 'weight')
+        nx.draw_networkx_edges(self.graph, pos, ax=ax)
+    

--- a/hytoperm/World.py
+++ b/hytoperm/World.py
@@ -45,6 +45,7 @@ class Region:
     """
     Represents an abstract region that.
     """
+    targetRegion : bool = False
 
     def region(self):
         return self
@@ -153,6 +154,9 @@ class Region:
 
     def isObstacle(self) -> bool:
         return False
+    
+    def isTargetRegion(self) -> bool:
+        return self.targetRegion
 
     def randomPoint(self) -> np.ndarray:
         pass
@@ -797,6 +801,7 @@ class World:
             raise ValueError("Expected argument of type Target.")
         if target not in self._targets:
             self._targets.append(target)
+            target.region().targetRegion = True
 
     def setPartition(self) -> None:
         self._partition = Partition(self.regions()) 

--- a/hytoperm/__init__.py
+++ b/hytoperm/__init__.py
@@ -4,3 +4,4 @@ from .World import *
 from .Sensor import *
 from .Agent import *
 from .Experiment import *
+from .Abstraction import *

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='hytoperm',
       'pdfCropMargins>=2.1.1',
       'scipy',
       'python-tsp>=0.4.0',
+      'networkx>=2.8.8'
    ]
 )
 

--- a/test/test_abstraction.py
+++ b/test/test_abstraction.py
@@ -1,0 +1,36 @@
+
+# external imports
+import unittest
+
+# internal imports
+from hytoperm import *
+
+
+class TestAbstraction(unittest.TestCase):
+    def testCompleteGraph(self):
+        ex = Experiment.generate(n_sets=20)
+        assert(isinstance(ex, Experiment))
+        gpp = GlobalPathPlanner(ex._world)
+        opts = AbstractionOptions()
+        opts.onlyDirectConnections = False
+        ga = GraphAbstraction(ex._world, gpp, opts)
+        
+        fig, ax = plt.subplots()
+        ga.plotAbstraction(ax=ax)
+        plt.close()
+
+    def testIncompleteGraph(self):
+        ex = Experiment.generate(n_sets=20)
+        assert(isinstance(ex, Experiment))
+        gpp = GlobalPathPlanner(ex._world)
+        opts = AbstractionOptions()
+        opts.onlyDirectConnections = True
+        ga = GraphAbstraction(ex._world, gpp, opts)
+        
+        fig, ax = plt.subplots()
+        ga.plotAbstraction(ax=ax)
+        plt.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_agent.py
+++ b/test/test_agent.py
@@ -69,5 +69,6 @@ class TestAgent(unittest.TestCase):
             agent.initializeCycle()
             agent._cycle.simulate()
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_world.py
+++ b/test/test_world.py
@@ -89,5 +89,6 @@ class TestWorld(unittest.TestCase):
         fig, ax = ex.plotWorld()
         ex.world().plotDomain(ax)   
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- generate a graph based on the target-to-target traveling distances computed via RRBT
- two versions: complete and incomplete
    -  the complete version generates a complete graph
    - the incomplete version drops any edge between two targets if the path traverses another target region
- uses the networkx package to represent the graph